### PR TITLE
WIP: Add typehint to factory classmethod of Flow

### DIFF
--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -9,6 +9,8 @@ from dataclasses import field
 from typing import Any
 from typing import ClassVar
 
+from typing_extensions import Self
+
 from mitmproxy import connection
 from mitmproxy import exceptions
 from mitmproxy import version
@@ -181,7 +183,7 @@ class Flow(serializable.Serializable):
         assert state == {}
 
     @classmethod
-    def from_state(cls, state: serializable.State) -> Flow:
+    def from_state(cls, state: serializable.State) -> Self:
         try:
             flow_cls = Flow.__types[state["type"]]
         except KeyError:


### PR DESCRIPTION
`mitmproxy.flow.Flow` has many derived classes `HTTPFlow`, `DNSFlow`, `TCPFlow`, `UDPFlow` and `DummyFlow`.
These derived classes call `from_state` of `flow.Flow`. The type returned by this from_state is currently `Flow`, but I think that it should be the type of the derived class.

This PR adds type hints to do so. `typing_extensions.Self` suits in this situation.

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
